### PR TITLE
net-vpn/lokinet: add dev-libs/spdlog to deps

### DIFF
--- a/net-vpn/lokinet/lokinet-0.9.11-r1.ebuild
+++ b/net-vpn/lokinet/lokinet-0.9.11-r1.ebuild
@@ -20,6 +20,7 @@ DEPEND="dev-vcs/git
     dev-util/cmake
     >=dev-libs/libuv-1.27
     dev-libs/openssl
+    dev-libs/spdlog
     net-misc/curl
     sys-libs/libunwind
     net-dns/unbound


### PR DESCRIPTION
I do not have any packages that install `spdlog` on my system. When I try to build lokinet without it, the build logs seemingly indicate that some local version of it is linked against. Once the build is done, it is discarded and attempting to run any of the lokinet binaries results in an error like this:
`lokinet: error while loading shared libraries: libspdlog.so.1: cannot open shared object file: No such file or directory`
I haven't really looked at this beyond noticing that installing spdlog separately will make the package link against that instead and actually work.
This PR fixes the issue for me.